### PR TITLE
added dns reverse resolution

### DIFF
--- a/logstash/dss_syslog.conf
+++ b/logstash/dss_syslog.conf
@@ -195,6 +195,48 @@ filter {
     code => "if event.get('[source][vlan]').nil?; event.set('[source][vlan]',9999);end"
   }
 
+  # Add DNS lookup for source and destination IP
+  # Copy IP fields before trying to resolve them
+  mutate {
+      copy => {
+          "[source][ip]" => "ip.source.host.name"
+          "[destination][ip]" => "ip.destination.host.name"
+      }
+  }
+  dns {
+      reverse => [ "ip.source.host.name", "ip.destination.host.name" ]
+      action => "replace"
+      # Store up to 131072 successful lookups
+      hit_cache_size => 131072
+      # Cache successful lookups for 15 minutes
+      hit_cache_ttl => 900
+      # Store up to 131,072 failed lookups
+      failed_cache_size => 131072
+      # Cache failed lookups for 15 minutes
+      failed_cache_ttl => 900
+
+      # Set timeout to prevent long-running DNS queries from blocking the pipeline
+      timeout => 2.0
+
+      # Add nameserver(s) ["10.0.0.10", "10.0.0.20"]
+      nameserver => {                             
+          address => ["10.29.32.11"]
+      }
+  }
+
+  # Fallback for source and destination IP if DNS resolution fails
+  # If DNS lookup failed, use the original IP address as the hostname value
+  if ![ip.source.host.name] {
+      mutate {
+          replace => { "ip.source.host.name" => "%{[source][ip]}" }
+      }
+  }
+  if ![ip.destination.host.name] {
+      mutate {
+          replace => { "ip.destination.host.name" => "%{[destination][ip]}" }
+      }
+  }
+
 #  # Perform conversions for ECS compatibility and remove items we no longer need
 #  mutate {
 #      add_field => { "[ecs][version]" => "8.0.0" }


### PR DESCRIPTION
added configurationfor dns reverse resolution:

- several dns servers can be used to enrich source and destination ip addresses
- a copy is made of source.ip and destination.ip source.ip.hostname / destination.ip.host.name
- a failed resolution will write the source.ip or destination.ip to the corresponding host.name field
- address => ["10.29.32.11"] has to be modified to match correct servers